### PR TITLE
Update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ resolvers += "Statismo (public)" at "http://shapemodelling.cs.unibas.ch/reposito
 resolvers += Opts.resolver.sonatypeSnapshots
 
 libraryDependencies  ++= Seq(
-    "ch.unibas.cs.gravis" %% "scalismo-faces" % "0.7.0"
+    "ch.unibas.cs.gravis" %% "scalismo-faces" % "0.7.1"
 )
 
 mainClass in assembly := Some("scalismo.faces.apps.LMClicker")

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ resolvers += "Statismo (public)" at "http://shapemodelling.cs.unibas.ch/reposito
 resolvers += Opts.resolver.sonatypeSnapshots
 
 libraryDependencies  ++= Seq(
-    "ch.unibas.cs.gravis" %% "scalismo-faces" % "0.5.0"
+    "ch.unibas.cs.gravis" %% "scalismo-faces" % "0.7.0"
 )
 
 mainClass in assembly := Some("scalismo.faces.apps.LMClicker")

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.4

--- a/project/sbtbintray.sbt
+++ b/project/sbtbintray.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 


### PR DESCRIPTION
Change to scalismo-faces v0.7.1 to fix issues when writing landmark files on an OS with different local settings. All human readable numberformats should now strictly use points only.